### PR TITLE
Play white pieces as strong as the black

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -115,7 +115,11 @@ def move_value(board, move, endgame):
     if board.is_capture(move):
         capture_value = evaluate_capture(board, move)
 
-    return -(capture_value + position_change)
+    current_move_value = capture_value + position_change
+    if board.turn == chess.BLACK:
+        current_move_value = -current_move_value
+
+    return current_move_value
 
 
 def evaluate_capture(board, move):
@@ -154,7 +158,11 @@ def evaluate_piece(piece, square, end_game):
 
 def evaluate_board(board):
     '''
-    Evaluate a board.
+    Evaluates the full board and determines which player is in a most favorable position.
+    The sign indicates the side:
+        (+) for white
+        (-) for black
+    The magnitude, how big of an advantage that player has
     '''
     total = 0
     end_game = check_end_game(board)

--- a/movegeneration.py
+++ b/movegeneration.py
@@ -1,3 +1,4 @@
+import chess
 import sys
 import time
 from evaluate import evaluate_board, move_value, check_end_game
@@ -13,7 +14,7 @@ def next_move(depth, board):
     debug['positions'] = 0
     t0 = time.time()
 
-    move = minimax_root(depth, board, True)
+    move = minimax_root(depth, board)
 
     debug['time'] = time.time() - t0
     print(f'>>> {debug}', file=sys.stderr)
@@ -31,21 +32,29 @@ def get_ordered_moves(board):
     def orderer(move):
         return move_value(board, move, end_game)
 
-    in_order = sorted(board.legal_moves, key=orderer, reverse=True)
+    in_order = sorted(board.legal_moves, key=orderer, reverse=(board.turn == chess.WHITE))
     return list(in_order)
 
 
-def minimax_root(depth, board, is_maximising_player):
+def minimax_root(depth, board):
+    # White always wants to maximize (and black to minimize)
+    # the board score according to evaluate_board()
+    maximize = board.turn == chess.WHITE
     best_move = -float('inf')
+    if not maximize:
+        best_move = float('inf')
     best_move_found = None
 
     moves = get_ordered_moves(board)
     for move in moves:
         board.push(move)
         value = minimax(depth - 1, board, -float('inf'),
-                        float('inf'), not is_maximising_player)
+                        float('inf'), not maximize)
         board.pop()
-        if value >= best_move:
+        if maximize and value >= best_move:
+            best_move = value
+            best_move_found = move
+        elif not maximize and value <= best_move:
             best_move = value
             best_move_found = move
 
@@ -56,7 +65,10 @@ def minimax(depth, board, alpha, beta, is_maximising_player):
     debug['positions'] += 1
 
     if depth == 0 or board.is_game_over():
-        return -evaluate_board(board)
+        if board.is_checkmate():
+            # The previous move resulted in checkmate
+            return -float('inf') if is_maximising_player else float('inf')
+        return evaluate_board(board)
 
     if is_maximising_player:
         best_move = -float('inf')

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -19,7 +19,10 @@ class TestCommunication(unittest.TestCase):
         self.assertEqual(board.fen(),
                          'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1')
 
-    def test_go_command(self):
+    def test_go_command_black(self):
+        '''
+        Test go command with Andoma playing with black pieces
+        '''
         board = chess.Board()
         with patch('sys.stdout', new=StringIO()) as patched_output:
             command(
@@ -46,3 +49,34 @@ class TestCommunication(unittest.TestCase):
 
             # black will threaten a bishop with a pawn (a very strong but not instantly obvious move)
             self.assertEqual(patched_output.getvalue().strip(), 'bestmove c5c4')
+
+    def test_go_command_white(self):
+        '''
+        Test go command with Andoma playing with white pieces
+        '''
+        board = chess.Board()
+        with patch('sys.stdout', new=StringIO()) as patched_output:
+            command(
+                3, board, 'position fen 6r1/8/R5pk/1P3p1p/3bn2P/1B3RP1/6K1/8 w - - 0 1')
+            command(3, board, 'go')
+
+            # white bishop should take a undefended rook
+            self.assertEqual(patched_output.getvalue().strip(), 'bestmove b3g8')
+
+        board = chess.Board()
+        with patch('sys.stdout', new=StringIO()) as patched_output:
+            command(
+                3, board, 'position fen rnb1kbnr/p1ppppqp/1p4p1/8/2P5/1P6/PB1PPPPP/RN2KBNR w KQkq - 0 1')
+            command(3, board, 'go')
+
+            # white will trade a bishop for a queen
+            self.assertEqual(patched_output.getvalue().strip(), 'bestmove b2g7')
+
+        board = chess.Board()
+        with patch('sys.stdout', new=StringIO()) as patched_output:
+            command(
+                3, board, 'position fen r2qkb1r/pppn1pp1/2n1b2p/4p3/3pPP2/3P2P1/PPPBN1BP/R2QK1NR w KQkq - 0 1')
+            command(3, board, 'go')
+
+            # white will threaten a bishop with a pawn (a very strong but not instantly obvious move)
+            self.assertEqual(patched_output.getvalue().strip(), 'bestmove f4f5')

--- a/test/test_evaluation.py
+++ b/test/test_evaluation.py
@@ -4,7 +4,10 @@ from evaluate import evaluate_board, move_value, check_end_game
 
 
 class TestEvaluation(unittest.TestCase):
-    def test_move_value(self):
+    def test_move_value_white(self):
+        '''
+        Test move_value function playing with white pieces
+        '''
         board = chess.Board(
             'rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1')
         move = chess.Move.from_uci('e4d5')
@@ -12,21 +15,55 @@ class TestEvaluation(unittest.TestCase):
         pawn_for_pawn = move_value(board, move, check_end_game(board))
 
         board = chess.Board(
-            'rnb1kbnr/ppp1pppp/8/3p1q2/4P3/3P1P2/PPP1B1PP/RNBQK1NR b KQkq - 0 1')
-        move = chess.Move.from_uci('f5e4')
+            'rnbqkbnr/ppp1pppp/8/3p4/2Q1P3/3P1P2/PPP1B1PP/RNB1K1NR w KQkq - 0 1')
+        move = chess.Move.from_uci('c4d5')
         # queen takes pawn
         queen_for_pawn = move_value(board, move, check_end_game(board))
+
+        self.assertEqual(queen_for_pawn, -800, f'Queen for pawn {queen_for_pawn} but it should be -800')
 
         board = chess.Board(
             'rnb1kbnr/ppp1pppp/8/3p1q2/4P3/3P1P2/PPP1B1PP/RNBQK1NR w KQkq - 0 1')
         move = chess.Move.from_uci('e4f5')
         # pawn takes queen
         pawn_for_queen = move_value(board, move, check_end_game(board))
+        self.assertEqual(pawn_for_queen, 775, f'Pawn for Queen {pawn_for_queen} but it should be 775')
 
-        correct_order = list(
+        worst_to_best = list(
             sorted([pawn_for_queen, pawn_for_pawn, queen_for_pawn]))
         self.assertEqual(
-            correct_order, [pawn_for_queen, pawn_for_pawn, queen_for_pawn])
+            worst_to_best, [queen_for_pawn, pawn_for_pawn, pawn_for_queen])
+
+    def test_move_value_black(self):
+        '''
+        Test move_value function playing with black pieces
+        '''
+        board = chess.Board(
+            'rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1')
+        move = chess.Move.from_uci('d5e4')
+        # pawn takes pawn
+        pawn_for_pawn = move_value(board, move, check_end_game(board))
+        self.assertEqual(pawn_for_pawn, 5, f'Pawn for pawn {pawn_for_pawn} but it should be 5')
+
+        board = chess.Board(
+            'rnb1kbnr/ppp1pppp/8/3p1q2/4P3/3P1P2/PPP1B1PP/RNBQK1NR b KQkq - 0 1')
+        move = chess.Move.from_uci('f5e4')
+        # queen takes pawn
+        queen_for_pawn = move_value(board, move, check_end_game(board))
+        self.assertEqual(queen_for_pawn, 800, f'Queen for pawn {queen_for_pawn} but it should be 800')
+
+        board = chess.Board(
+            'rnbqkbnr/ppp1pppp/8/3p4/2Q1P3/3P1P2/PPP1B1PP/RNB1K1NR b KQkq - 0 1')
+        move = chess.Move.from_uci('d5c4')
+        # pawn takes queen
+        pawn_for_queen = move_value(board, move, check_end_game(board))
+
+        self.assertEqual(pawn_for_queen, -775, f'Pawn for queen {pawn_for_queen} but it should be -775')
+
+        best_to_worst = list(
+            sorted([pawn_for_queen, pawn_for_pawn, queen_for_pawn]))
+        self.assertEqual(
+            best_to_worst, [pawn_for_queen, pawn_for_pawn, queen_for_pawn])
 
     def test_end_game(self):
         # starting fen


### PR DESCRIPTION
Solves #1.

This PR sets the maximizing player as white and minimizing player as black. Changes include:
    
 - Update tests to verify the bot's behavior playing white and black pieces.
  - The bot should choose to checkmate the opponent, and avoid making moves that lead to being checkmated, whenever it is possible.
  - Update comments for clarity.