### PR TITLE
Use sys.exit() instead of quit()

### DIFF
--- a/communication.py
+++ b/communication.py
@@ -24,7 +24,7 @@ def command(depth, board, msg):
     The board state is also updated.
     '''
     if msg == 'quit':
-        quit()
+        sys.exit()
 
     if msg == 'uci':
         print("id name Andoma")  # Andrew/Roma -> And/oma


### PR DESCRIPTION
Calling `quit()` only works in the interpreter, use `sys.exit()` instead. 

When running Andoma with `lichess-bot` the error `NameError: name 'quit' is not defined` should no longer appear when uci command `quit` is received.