### PR TITLE
Avoid draw while in a favorable position

### DIFF
--- a/movegeneration.py
+++ b/movegeneration.py
@@ -48,8 +48,14 @@ def minimax_root(depth, board):
     moves = get_ordered_moves(board)
     for move in moves:
         board.push(move)
-        value = minimax(depth - 1, board, -float('inf'),
-                        float('inf'), not maximize)
+        # Checking if draw can be claimed at this level, because the threefold repetition check
+        # can be expensive. This should help the bot avoid a draw if it's not favorable
+        # https://python-chess.readthedocs.io/en/latest/core.html#chess.Board.can_claim_draw
+        if board.can_claim_draw():
+            value = 0
+        else:
+            value = minimax(depth - 1, board, -float('inf'),
+                            float('inf'), not maximize)
         board.pop()
         if maximize and value >= best_move:
             best_move = value
@@ -64,10 +70,15 @@ def minimax_root(depth, board):
 def minimax(depth, board, alpha, beta, is_maximising_player):
     debug['positions'] += 1
 
-    if depth == 0 or board.is_game_over():
-        if board.is_checkmate():
-            # The previous move resulted in checkmate
-            return -float('inf') if is_maximising_player else float('inf')
+    if board.is_checkmate():
+        # The previous move resulted in checkmate
+        return -float('inf') if is_maximising_player else float('inf')
+    # When the game is over and it's not a checkmate it's a draw
+    # In this case, don't evaluate. Just return a neutral result: zero
+    elif board.is_game_over():
+        return 0
+
+    if depth == 0:
         return evaluate_board(board)
 
     if is_maximising_player:

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -80,3 +80,16 @@ class TestCommunication(unittest.TestCase):
 
             # white will threaten a bishop with a pawn (a very strong but not instantly obvious move)
             self.assertEqual(patched_output.getvalue().strip(), 'bestmove f4f5')
+
+    def test_draw(self):
+        '''
+        Test go command with Andoma on the verge of drawing due to threefold repetition
+        '''
+        board = chess.Board()
+        with patch('sys.stdout', new=StringIO()) as patched_output:
+            command(
+                3, board, 'position startpos moves c2c4 d7d6 d1a4 c8d7 a4a5 b8c6 a5b5 a7a6 b5b7 c6e5 b1c3 e5c4 g1f3 d7c8 b7a8 g8f6 a8c6 c8d7 c6c4 d6d5 c4a6 e7e6 f3e5 f8d6 e5d7 d8d7 a6a8 d7d8 a8c6 d8d7 c6a8 d7d8 a8c6 d8d7')
+            command(3, board, 'go')
+
+            # Bot is in a favorable position, should avoid threefold repetition
+            self.assertNotEqual(patched_output.getvalue().strip(), 'bestmove c6a8')


### PR DESCRIPTION
Andoma constantly makes the final move of a threefold repetition resulting in a draw, even when it has a massive advantage.

This PR solves this issue by assigning draw a neutral value of zero, and checking if the opponent can claim a draw.