### PR TITLE
Reduce the score of a checkmating move each ply

### DIFF
--- a/movegeneration.py
+++ b/movegeneration.py
@@ -7,6 +7,10 @@ from evaluate import evaluate_board, move_value, check_end_game
 debug_info: Dict[str, Any] = {}
 
 
+MATE_SCORE     = 1000000000
+MATE_THRESHOLD =  999000000
+
+
 def next_move(depth: int, board: chess.Board, debug=True) -> chess.Move:
     """
     What is the next best move?
@@ -89,7 +93,7 @@ def minimax(
 
     if board.is_checkmate():
         # The previous move resulted in checkmate
-        return -float("inf") if is_maximising_player else float("inf")
+        return -MATE_SCORE if is_maximising_player else MATE_SCORE
     # When the game is over and it's not a checkmate it's a draw
     # In this case, don't evaluate. Just return a neutral result: zero
     elif board.is_game_over():
@@ -103,9 +107,16 @@ def minimax(
         moves = get_ordered_moves(board)
         for move in moves:
             board.push(move)
+            curr_move = minimax(depth - 1, board, alpha, beta, not is_maximising_player)
+            # Each ply after a checkmate is slower, so they get ranked slightly less
+            # We want the fastest mate!
+            if curr_move > MATE_THRESHOLD:
+                curr_move -= 1
+            elif curr_move < -MATE_THRESHOLD:
+                curr_move += 1
             best_move = max(
                 best_move,
-                minimax(depth - 1, board, alpha, beta, not is_maximising_player),
+                curr_move,
             )
             board.pop()
             alpha = max(alpha, best_move)
@@ -117,9 +128,14 @@ def minimax(
         moves = get_ordered_moves(board)
         for move in moves:
             board.push(move)
+            curr_move = minimax(depth - 1, board, alpha, beta, not is_maximising_player)
+            if curr_move > MATE_THRESHOLD:
+                curr_move -= 1
+            elif curr_move < -MATE_THRESHOLD:
+                curr_move += 1
             best_move = min(
                 best_move,
-                minimax(depth - 1, board, alpha, beta, not is_maximising_player),
+                curr_move,
             )
             board.pop()
             beta = min(beta, best_move)

--- a/test/test_puzzles.py
+++ b/test/test_puzzles.py
@@ -12,3 +12,9 @@ class TestPuzzles(unittest.TestCase):
         )
         move = next_move(3, board)
         self.assertEqual(move.uci(), "f5g6")
+
+    def test_mate_in_one(self):
+        # Multiple mate in 2s/3s, but only one mate in 1
+        board = chess.Board("6k1/8/8/5r2/8/8/4r3/2K5 b - - 1 1")
+        move = next_move(3, board)
+        self.assertEqual(move.uci(), "f5f1")


### PR DESCRIPTION
Hi, I've got another pull request as well :)

I noticed that the bot doesn't distinguish between how long it will take to do a checkmating move. As long as it knows it has a forced checkmate, it gives it the highest score. The problem is that even if the bot has mate in 1, it won't necessarily play it as it might randomly choose to play a mate in 2 (or higher if the depth is turned up) move instead.

This pull request replaces the scores from being `inf` or `-inf`, to instead being `1000000000` which I believe is higher than the evaluation function can ever output. Then, each ply, subtract 1 from a score if it's a mate score (which I say is a score higher than `999000000`. That should work so long as there aren't any mate in 1 millions ;) ) This means, that a mate in 1 is slightly better than a mate in 2, and that a mate in 2 is slightly better than mate in 3, etc.

During debugging, I added a line in `minimax_root` that prints the evaluation for each move. I set it up with a simple fen position `6k1/8/8/5r2/8/8/4r3/2K5 b - - 1 1` which demonstrates the problem. Here is what it looks like with the original code (annotated with comments):
```
uci
id name Andoma
id author Andrew Healey & Roma Parramore
uciok
position fen 6k1/8/8/5r2/8/8/4r3/2K5 b - - 1 1
go      
info move g8h8 has eval -1100
info move g8f7 has eval -1070
info move f5f2 has eval -1100
info move g8f8 has eval -1040
info move g8h7 has eval -1090
info move g8g7 has eval -1090
info move f5f8 has eval -1090
info move f5f7 has eval -1090
info move f5f6 has eval -1090
info move f5g5 has eval -1090
info move f5e5 has eval -1090
info move f5d5 has eval -inf      <-- notice they are all -inf!
info move f5c5 has eval -1090
info move f5b5 has eval -1090
info move f5f4 has eval -1090
info move f5f3 has eval -1090
info move f5f1 has eval -inf      <-- 
info move e2g2 has eval -inf      <-- 
info move e2f2 has eval -1090
info move e2d2 has eval -550
info move e2c2 has eval -550
info move e2b2 has eval -580
info move f5h5 has eval -1085
info move f5a5 has eval -1085
info move e2e8 has eval -1055
info move e2h2 has eval -inf      <-- 
info move e2a2 has eval -1085
info move e2e7 has eval -1050
info move e2e6 has eval -1050
info move e2e5 has eval -1050
info move e2e4 has eval -1050
info move e2e3 has eval -1050
info move e2e1 has eval -1050
info {'nodes': 1227, 'time': 0.13769292831420898}
bestmove e2h2                   <- doesn't know which -inf was best.
```

Here is what it looks like now:
```
uci
id name Andoma
id author Andrew Healey & Roma Parramore
uciok
position fen 6k1/8/8/5r2/8/8/4r3/2K5 b - - 1 1
go
info move g8h8 has eval -1100
info move g8f7 has eval -1070
info move f5f2 has eval -1100
info move g8f8 has eval -1040
info move g8h7 has eval -1090
info move g8g7 has eval -1090
info move f5f8 has eval -1090
info move f5f7 has eval -1090
info move f5f6 has eval -1090
info move f5g5 has eval -1090
info move f5e5 has eval -1090
info move f5d5 has eval -999999998     <-   Mate in 2! Good, but not as good as...
info move f5c5 has eval -1090
info move f5b5 has eval -1090
info move f5f4 has eval -1090
info move f5f3 has eval -1090
info move f5f1 has eval -1000000000    <-   Mate in 1!!
info move e2g2 has eval -999999998
info move e2f2 has eval -1090
info move e2d2 has eval -550
info move e2c2 has eval -550
info move e2b2 has eval -580
info move f5h5 has eval -1085
info move f5a5 has eval -1085
info move e2e8 has eval -1055
info move e2h2 has eval -999999998
info move e2a2 has eval -1085
info move e2e7 has eval -1050
info move e2e6 has eval -1050
info move e2e5 has eval -1050
info move e2e4 has eval -1050
info move e2e3 has eval -1050
info move e2e1 has eval -1050
info {'nodes': 1310, 'time': 0.14292550086975098}
bestmove f5f1                           <-   It now picks the best move
```

Thanks for making this engine and writing up about it, I've been having fun looking through the code.