### PR TITLE
Add "SearchDepth" UCI option

### DIFF
--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -13,9 +13,9 @@ class TestCommunication(unittest.TestCase):
         board = chess.Board()
         with patch("sys.stdout", new=StringIO()) as patched_output:
             command(3, board, "uci")
-            lines = patched_output.getvalue().strip().split("\n")
-            self.assertEqual(len(lines), 3)
-            self.assertEqual(lines[2], "uciok")
+            lines = patched_output.getvalue().strip().splitlines()
+            self.assertEqual(len(lines), 4)
+            self.assertEqual(lines[-1], "uciok")
 
     def test_position_startpos_command(self):
         """


### PR DESCRIPTION
Leaving this here for now. It works, though I'm not totally happy with it.

This pull request adds a UCI option `SearchDepth` which controls the depth at which the engine will search. This allows you to set the depth of the engine using the menu of a UCI compatible chess engine. I tested it with Cute Chess and it works as intended. Also, the command line option `--depth` still works as normal.

Here is what I don't like:

I converted the variable `depth` into a global variable so it persists over time and can be modified when a `setoption` command comes in. What I wanted to do is remove `depth` as a parameter from the `command` function, and just have it read that global variable instead. But python isn't my strongest language, and I can't quite figure out how to get the unit testing suite to be able to set or read that variable. I tried importing it, I tried just declaring it as a global and seeing if it would match it with the global from the other file, but I couldn't quite figure it out. So, maybe you know what I've done wrong here.

So instead, I just kept `depth` as a parameter, and made a new `search_depth` global variable. `setoption` modifies that global variable rather than the local one.

I wanted to write a test case that checked that the `setoption` command works as intended, but again, I couldn't figure out how to get the testing file to properly read the value! I wrote the following test:
```python
    def test_setoption_searchdepth(self):
        """
        Test setoption command setting the current search depth
        """
        board = chess.Board()
        global search_depth
        search_depth = 3
        command(search_depth, board, "setoption name SearchDepth value 5")
        self.assertEqual(search_depth, 5)
```
I believe the above test _should_ work, but it says that the assertion failed because 3 != 5. I checked running the command manually in UCI mode, and that command definitely is working as intended. Maybe you know why this test isn't working :P

I don't think this PR should be merged as-is. If you can help me understand python better and get that global variable to be readable/writeable from both files, then we can remove the redundant parameter from `command` and just have it read the global while also adding in the new test.

Let me know your thoughts! :)